### PR TITLE
Hide ATC button for guests + Hide "Create Account" on login page

### DIFF
--- a/sections/main-login.liquid
+++ b/sections/main-login.liquid
@@ -139,10 +139,12 @@
       <button>
         {{ 'customer.login_page.sign_in' | t }}
       </button>
-
+              
+{% comment %} Hides "Create Account" link
       <a href="{{ routes.account_register_url }}">
         {{ 'customer.login_page.create_account' | t }}
       </a>
+{% endcomment %}
       
     {%- endform -%}
   </div>

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -626,7 +626,7 @@
                     >
                     
                     {% render 'embroidery-input-product' %}
-
+                    {% if customer %}
                     <div class="product-form__buttons">
                     
                       <button
@@ -662,6 +662,7 @@
                           {{ form | payment_button }}
                         {%- endif -%}
                     </div>
+                      {% endif %}
                   {%- endform -%}
                 </product-form>
 


### PR DESCRIPTION
Hides ATC button for guests using logic in the product template.

Also commented out the link on the login page that allows people to create an account