### PR TITLE
Ft na 221123 embroidery final sale

### DIFF
--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -244,6 +244,7 @@
               </div>
             {%- endif -%}
 {% render "color-warning" %}
+{% render "embroidery-sale-warning" %}
             
             <p id="CartDrawer-LiveRegionText" class="visually-hidden" role="status"></p>
             <p id="CartDrawer-LineItemStatus" class="visually-hidden" aria-hidden="true" role="status">{{ 'accessibility.loading' | t }}</p>

--- a/snippets/embroidery-product.liquid
+++ b/snippets/embroidery-product.liquid
@@ -78,7 +78,7 @@ Embroidery control module for PDP
           </div>
           <span id="embroidery-logo-selection">{{ emb_variants.first.title }}: {{ emb_variants.first.price | money }}</span>
           
-          
+          {% render "embroidery-sale-warning" %}
         </div>
       </details>
     </div>

--- a/snippets/embroidery-sale-warning.liquid
+++ b/snippets/embroidery-sale-warning.liquid
@@ -1,0 +1,3 @@
+<div class="embroidery-sale-warning">
+  <p class="warning-message">All embroidered products are <strong>final</strong> sale and cannot be returned.</p>
+</div>


### PR DESCRIPTION
### PR Summary: 

This PR adds an embroidery warning for the cart and embroidered section for products that have embroidery to let the customer know the all embroidered sales are final and cannot be returned. A snippet was created (embroidery-sale-warning.liquid), and rendered in the cart-drawer.liquid (line 247) and the embroidery-product.liquid (line 81)